### PR TITLE
update sendFile method name to supress deprecation warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strider-build-badge",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Enables strider to have build status badges",
   "main": "webapp.js",
   "publishConfig": {

--- a/webapp.js
+++ b/webapp.js
@@ -10,7 +10,7 @@ module.exports = function (context, done) {
         console.error('[badge] error occured when getting badge: ' + error.message)
       }
       res.setHeader('Cache-Control', 'no-cache')
-      res.sendfile(__dirname + '/images/' + imageName)
+      res.sendFile(__dirname + '/images/' + imageName)
     })
   })
   done()


### PR DESCRIPTION
There is a deprecation warning that is produced, this small PR just uses the preferred method (`sendFile`) now.

Thanks!